### PR TITLE
#メッセージ自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,11 +1,12 @@
 $(function(){
 
+  // 送信したメッセージ（HTML）の作成
   function buildHTML(message){
     var image = " ";
     if(message.image){
       image = `<image src = "${message.image}">`;
     };
-    var html = `<div class="messages">
+    var html = `<div class="messages" data-massage-id="${message.id}">
                  <div class="messages__name">
                   ${message.user_name}
                  </div>
@@ -22,6 +23,7 @@ $(function(){
     return html;
   };
 
+  // メッセージ送信を非同期通信で行う
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -40,9 +42,41 @@ $(function(){
       $('.chat').append(html);
       $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight},'fast');
       $('.submit-form').prop('disabled', false);
+      $('.type-message').val('')
+      $('#message_image').val('')
     })
-     .fail(function(){
-      alert('error');
+     .fail(function(data){
+      alert('メッセージを入力してください');
     });
+     return false;
   });
+
+  // メッセージの自動更新
+  var interval = setInterval(function() {
+    if(window.location.href.match(/\/groups\/\d+\/messages/)){
+      var id = $('.messages:last').data('messageId');
+
+      $.ajax({
+        url: location.href,
+        data: { id : id },
+        type: "GET",
+        dataType: 'json'
+      })
+      .done(function(data){
+        var HTML = '';
+        data.messages.forEach(function(message){
+          if(message.id > id){
+            HTML += buildHTML(message);
+            $('.chat').append(HTML);
+            $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight},'fast');
+          }
+        })
+      })
+      .fail(function(){
+        alert('error');
+      });
+    }
+    else {
+      clearInterval(interval);
+    }} , 5000 );
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -65,11 +65,9 @@ $(function(){
       .done(function(data){
         var HTML = '';
         data.messages.forEach(function(message){
-          if(message.id > id){
             HTML += buildHTML(message);
             $('.chat').append(HTML);
             $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight},'fast');
-          }
         })
       })
       .fail(function(){

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -65,9 +65,9 @@ $(function(){
       .done(function(data){
         var HTML = '';
         data.messages.forEach(function(message){
-            HTML += buildHTML(message);
-            $('.chat').append(HTML);
-            $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight},'fast');
+          HTML += buildHTML(message);
+          $('.chat').append(HTML);
+          $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight},'fast');
         })
       })
       .fail(function(){

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,6 +4,10 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @messages = @group.messages.includes(:user)
+    respond_to do |format|
+      format.html
+      format.json{ @new_messages = @messages.where('id > ?', params[:id]) }
+    end
     @member = @group.users
   end
 

--- a/app/views/messages/_message.haml
+++ b/app/views/messages/_message.haml
@@ -1,8 +1,8 @@
-.messages
+.messages{ "data-message-id": "#{message.id}" }
  .messages__name
   = message.user.name
  .messages__time
-  = simple_time(message.created_at)
+  = message.created_at.strftime("%Y年%m月%d日 %H:%M")
  .messages__text
   - if message.body.present?
    %p.messages__text__body

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.messages @new_messages.each do |message|
+  json.id  message.id
+  json.body  message.body
+  json.image  message.image.url
+  json.created  message.created_at.strftime("%Y年%m月%d日 %H:%M")
+  json.user_id  message.user.id
+  json.user_name  message.user.name
+end


### PR DESCRIPTION
#WHAT

.data(‘messageId’)..
現在表示されている画面の最新のメッセージのidを取得し、変数idに代入
.done(function(data)…

$.ajax({ ..
messageコントローラーのindexアクションを動かすリクエストを送る（Indexアクション内で、HTMLとjsonで処理を分ける。）

.done(function(data){..
現在の画面上のメッセージよりも、新しいメッセージが存在する場合、そのメッセージを表示する（HTMLの追加)

if(window.location.href.match(/\/groups\/\d+\/…
clearInterval(interval);
    }} , 5000 )
チャット画面のページで、5秒ごとに自動更新が行われるようにし、他のページに飛んだ場合は、自動更新が行われないようにする。

#WHY
他のユーザーが投稿したメッセージも表示されるようにするため。（チャットとして必要な機能）
