### PR TITLE
#グループ編集画面の微修正

### DIFF
--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -22,10 +22,13 @@
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
       #chat-group-users
-        .chat-group-user
-          %input{ name: "group[user_ids][]", type: "hidden", value: current_user.id}/
-          %p.chat-group-user__name
-            = current_user.name
+        - @group.users.each do |user|
+          .chat-group-user
+            %input{ name: "group[user_ids][]", type: "hidden", value: user.id}/
+            %p.chat-group-user__name
+              = user.name
+            - unless user.id == current_user.id
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove{ 'data-user-id': user.id } 削除
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right


### PR DESCRIPTION
#WHAT
 @group.users.each do |user|
   .chat-group-user...    
　　user.name         ・・グループに追加した、既存のユーザーの名前を表示するようにする。

#WHY
グループ編集画面に遷移した際、当該グループに所属しているユーザーの名前が全て表示されていないので、修正した。